### PR TITLE
Some bugfixes and updates

### DIFF
--- a/beam/ext.py
+++ b/beam/ext.py
@@ -234,6 +234,22 @@ class BeamSmallBigExt(object):
         value = content.read(n)
         return BeamSmallBigExt(sign, value)
 
+class BeamExportExt(object):
+    def __init__(self, module, function, arity):
+        self.__module = module
+        self.__function = function
+        self.__arity = arity
+
+    @staticmethod
+    def parse(content):
+        module = BeamExtTerm.parse(content, marker_required=False)
+        function = BeamExtTerm.parse(content, marker_required=False)
+        arity = BeamExtTerm.parse(content, marker_required=False)
+        return BeamExportExt(module.value, function.value, arity.value)
+
+    def __repr__(self):
+        return f'fun {self.__module.decode("utf-8")}:{self.__function.decode("utf-8")}/{self.__arity}'
+
 class BeamLargeBigExt(BeamSmallBigExt):
     def __init__(self, sign, value):
         super().__init__(sign, value)
@@ -300,6 +316,7 @@ class BeamExtTerm(object):
         108: BeamListExt,
         109: BeamBinaryExt,
         110: BeamSmallBigExt,
+        113: BeamExportExt,
         115: BeamSmallAtomExt,
         116: BeamMapExt,
         118: BeamAtomUtf8Ext,

--- a/beam/instset.py
+++ b/beam/instset.py
@@ -1877,6 +1877,24 @@ class BeamInstBsMatch(BeamInst):
     def __init__(self):
         super().__init__('bs_match')
 
+#
+# OTP 27
+#
+
+@opcode(183, 2)
+class BeamInstExecutableLine(BeamInst):
+    def __init__(self):
+        super().__init__('executable_line')
+
+#
+# OTP 28
+#
+
+@opcode(184, 4)
+class BeamInstDebugLine(BeamInst):
+    def __init__(self):
+        super().__init__('debug_line')
+
 
 class BeamInstParser(object):
     '''BEAM instruction parser

--- a/beam/sections.py
+++ b/beam/sections.py
@@ -64,12 +64,14 @@ class BeamLineSection(object):
         fname_index = 0
 
 
-        for i in range(num_line_refs):
+        i = 0
+        while i < num_line_refs:
             term = BeamCompactTerm.read_term(content)
             if isinstance(term, BeamInteger):
                 section.add_line_ref(fname_index, term.value)
+                i += 1
             elif isinstance(term, BeamAtom):
-                fname_index = term.index
+                fname_index = term.index - 1
                 assert fname_index < num_filenames
 
         for i in range(num_filenames):

--- a/beam/sections.py
+++ b/beam/sections.py
@@ -364,9 +364,12 @@ class BeamLiteralSection(object):
         # Read uncompressed size
         uncompressed_size = unpack('>I', content.read(4))[0]
 
-        # Read compressed data and decompress
-        compressed_data = content.getvalue()[4:]
-        data = BytesIO(decompress(compressed_data))
+        # Read possibly compressed data and decompress if needed
+        if uncompressed_size == 0:
+            data = BytesIO(content.getvalue()[4:])
+        else:
+            compressed_data = content.getvalue()[4:]
+            data = BytesIO(decompress(compressed_data))
 
         # Parse decompressed data
         value_count = unpack('>I', data.read(4))[0]

--- a/beam/types.py
+++ b/beam/types.py
@@ -151,6 +151,29 @@ class BeamExtList(object):
         items = ','.join(['%s' % str(v) for v in self.__items])
         return 'BeamList(%s)' % items
 
+class BeamExtAllocList(object):
+    '''Represents a BEAM extended allocation list
+    '''
+    def __init__(self):
+        super().__init__()
+        self.__items = []
+
+    def __len__(self):
+        return len(self.__items)
+
+    def __getitem__(self, index):
+        if index < len(self.__items):
+            return self.__items[index]
+        raise IndexError
+
+    def add(self, key, value):
+        self.__items.append((key, value))
+
+    def __repr__(self):
+        #pairs = ','.join(['(%s, %s)' % (str(k), str(v)) for k,v in self.__pairs])
+        items = ','.join(['%s' % str(v) for v in self.__items])
+        return 'BeamAllocList(%s)' % items
+
 class BeamFpReg(object):
     '''Represents an FR register
     '''

--- a/beam/utils.py
+++ b/beam/utils.py
@@ -3,7 +3,7 @@
 
 from .exceptions import UnsupportedBeamCompactTerm
 from .types import BeamAtom, BeamInteger, BeamChar, BeamLabel, BeamLiteral, \
-    BeamNIL, BeamXReg, BeamYReg, BeamExtList, BeamFpReg, BeamTypedReg
+    BeamNIL, BeamXReg, BeamYReg, BeamExtList, BeamExtAllocList, BeamFpReg, BeamTypedReg
 
 class BeamCompactTerm(object):
 
@@ -71,12 +71,12 @@ class BeamCompactTerm(object):
             return list_obj
         elif value_type == BeamCompactTerm.TYPE_EXT_ALST:
             # Read smallint
-            list_obj = BeamExtList()
+            list_obj = BeamExtAllocList()
             literal = BeamCompactTerm.read_term(source)
-            for i in range(int(literal.index/2)):
-                #key = BeamCompactTerm.read_term(source)
+            for i in range(int(literal.index)):
+                key = BeamCompactTerm.read_term(source)
                 value = BeamCompactTerm.read_term(source)
-                list_obj.add(value)
+                list_obj.add(key, value)
             return list_obj
         elif value_type == BeamCompactTerm.TYPE_EXT_FPREG:
             # Read tag and value


### PR DESCRIPTION
Hey, I recently used this disassembler for one of the competition challenges in the 2025 DEF CON CTF, and as part of that, I had to make some adjustments for it to work properly with BEAM files for OTP 28. Given what you wrote in your slides for Pass The Salt 2024, I'm not sure if you're interested in PRs for this repo, but I figured it wouldn't hurt to offer to upstream my changes.

Some of these commits are definitely for things that were changed in OTP 27 or 28; I tried to keep backwards compatibility in those cases. I _think_ the other changes are bugfixes for code that probably never worked correctly, but it's possible that they're also related to recent OTP changes that I'm not aware of.